### PR TITLE
Stop the modal from rendering null on isOpen === false

### DIFF
--- a/components/ModalPortal.jsx
+++ b/components/ModalPortal.jsx
@@ -16,11 +16,6 @@ if (typeof window !== 'undefined') {
 
 var styleReset = {
     overlay: {
-        // position        : null,
-        // top             : null,
-        // left            : null,
-        // right           : null,
-        // bottom          : null,
         backgroundColor : null
     },
     content: {
@@ -65,7 +60,7 @@ var Modal = React.createClass({
         }
     },
     render: function() {
-        if (!this.state.loaded && !this.props.isOpen) {
+        if (!this.state.loaded) {
             return null;
         }
 


### PR DESCRIPTION
This forces the modal to unmount too soon which stops
ReactModal from removing its classNames from the body.
