### PR TITLE
Bump to 0.4.19; remove modal isLoaded check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bd-stampy",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "React UI Component Library",
   "main": "stampy.js",
   "scripts": {


### PR DESCRIPTION
Updating to patch 0.4.19 version —
Removes check on render for modal "isLoaded" ;
was preventing modals from opening at all. 
