### PR TITLE
Feature/auto request update

### DIFF
--- a/components/AutoRequest.jsx
+++ b/components/AutoRequest.jsx
@@ -1,27 +1,26 @@
 import React, { Component, PropTypes } from 'react';
-import {fromJS} from 'immutable';
+import Immutable, {fromJS} from 'immutable';
 
 export default (propKeys, outputFunction) => (ComposedComponent) => {
     return class AutoRequest extends Component {
-        constructor(props, context) {
-            super(props, context);
-        }
         componentWillMount() {
             outputFunction(this.props);
         }
         componentWillReceiveProps(nextProps) {
             // make props immutable Maps
-            var thisPropsImmutable = fromJS(this.props);
-            var nextPropsImmutable = fromJS(nextProps);
+            const thisPropsImmutable = fromJS(this.props);
+            const nextPropsImmutable = fromJS(nextProps);
 
-            var booleanTest = propKeys
-                .map(ii => {
-                    var keyPath = ii.split('.');
-                    return thisPropsImmutable.getIn(keyPath) !== nextPropsImmutable.getIn(keyPath);
-                })
-                .indexOf(true)
+            const propsHaveChanged = fromJS(propKeys)
+                .some(ii => {
+                    const keyPath = ii.split('.');
+                    return !Immutable.is(
+                        thisPropsImmutable.getIn(keyPath),
+                        nextPropsImmutable.getIn(keyPath)
+                    );
+                });
 
-            if(booleanTest !== -1) {
+            if(propsHaveChanged) {
                 outputFunction(nextProps);
             }
         }

--- a/components/QueryStringProvider.jsx
+++ b/components/QueryStringProvider.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
-import { fromJS, List } from 'immutable';
+import Immutable, { fromJS, List } from 'immutable';
+import AutoRequest from 'bd-stampy/components/AutoRequest';
 
 //
 // QueryStringProvider higher order component
@@ -10,7 +11,7 @@ import { fromJS, List } from 'immutable';
 // + updateQuery - a function to updates only parts of the query at once. Good at not demolishing other query params not set by this component
 // + setQuery - a function to set the query
 //
-// This higher order component accepts a single object to pass conguration options in
+// This higher order component accepts a config object to pass conguration options in
 // Valid options are
 // + queryPropName - optional string, sets the name of the query prop. Defaults to "query"
 // + replaceState - optional boolean, setting this to true will make query changes use replaceState instead of pushState
@@ -18,15 +19,26 @@ import { fromJS, List } from 'immutable';
 //   by default react-router only passes an array of query param values back if there are more than one
 //   All arrayParams will also be an empty array if they are not present in the query string
 //
-// This component requires a location prop anmd history prop passed to it, which should be the location and history props that react router provides it's route components
-// This will happen automatically if this HOC is used on any components used straight from <Route> objects
+// This higher order component's second argument is the onChangeFunction, which if provided will call onChangeFunction once on componentDidMount, 
+// and each time the query changes after that. onChangeFunction will be passed 2 arguments: the current query object and a props object.
+//
+// This component requires a location prop, which should be the location pros that react router provides it's route components
+// This will happen automatically if this HOC is used on any components being passed straight to <Route> objects
+// If you're using react-router v1 then you'll also need to pass it a history prop that react-router provides
+// If using react-router v2 then QueryStringProvider will automatically connect via context
 //
 
-export default (config) => (ComposedComponent) => {
+export default (config, onChangeFunction) => (ComposedComponent) => {
 
     const replaceState = config && config.replaceState;
     const queryPropName = (config && config.queryPropName) || "query";
     const arrayParams = (config && fromJS(config.arrayParams)) || List();
+
+    const PreparedComposedComponent = !onChangeFunction
+        ? ComposedComponent
+        : AutoRequest(['query'], (props) => {
+            onChangeFunction(props[queryPropName], props);
+        })(ComposedComponent);
 
     class QueryStringProvider extends Component {
 
@@ -41,8 +53,8 @@ export default (config) => (ComposedComponent) => {
         // getQuery()
         // gets the query object
 
-        getQuery() {
-            const query = fromJS(this.props.location.query);
+        getQuery(props = this.props) {
+            const query = fromJS(props.location.query);
 
             // ensures that all arrayParams are returned as arrays (not strings or blank)
             return arrayParams
@@ -70,12 +82,21 @@ export default (config) => (ComposedComponent) => {
         // empty strings will be ignored and removed from the query string
 
         setQuery(query) {
-            const routerMethod = replaceState ? "replaceState" : "pushState";
+            const routerMethod = replaceState ? "replace" : "push";
             const newQuery = fromJS(query)
                 .filter(ii => ii !== "")
-                .toJS()
+                .toJS();
 
-            this.props.history[routerMethod](null, this.props.location.pathname, newQuery);
+            if(this.context.router) {
+                // react router v2
+                this.context.router[routerMethod]({
+                    pathname: this.props.location.pathname,
+                    query: newQuery
+                });
+            } else {
+                // react router v1
+                this.props.history[`${routerMethod}State`](null, this.props.location.pathname, newQuery);
+            }
         }
 
         // render()
@@ -86,13 +107,17 @@ export default (config) => (ComposedComponent) => {
                 setQuery: this.setQuery,
                 updateQuery: this.updateQuery
             };
-            return <ComposedComponent {...this.props} {...newProps} />;
+            return <PreparedComposedComponent {...this.props} {...newProps} />;
         }
     }
 
     QueryStringProvider.propTypes = {
         location: PropTypes.object.isRequired, // must be react router location object
-        history: PropTypes.object.isRequired // must be react router history object
+        history: PropTypes.object // must be react router history object, required for react-router v1
+    };
+    
+    QueryStringProvider.contextTypes = {
+        router: React.PropTypes.func // required for react-router v2
     };
 
     return QueryStringProvider;

--- a/components/QueryStringProvider.jsx
+++ b/components/QueryStringProvider.jsx
@@ -11,7 +11,7 @@ import AutoRequest from 'bd-stampy/components/AutoRequest';
 // + updateQuery - a function to updates only parts of the query at once. Good at not demolishing other query params not set by this component
 // + setQuery - a function to set the query
 //
-// This higher order component accepts a config object to pass conguration options in
+// This higher order component accepts a config object to pass configuration options in
 // Valid options are
 // + queryPropName - optional string, sets the name of the query prop. Defaults to "query"
 // + replaceState - optional boolean, setting this to true will make query changes use replaceState instead of pushState
@@ -36,7 +36,7 @@ export default (config, onChangeFunction) => (ComposedComponent) => {
 
     const PreparedComposedComponent = !onChangeFunction
         ? ComposedComponent
-        : AutoRequest(['query'], (props) => {
+        : AutoRequest([queryPropName], (props) => {
             onChangeFunction(props[queryPropName], props);
         })(ComposedComponent);
 


### PR DESCRIPTION
- AutoRequest now compares props deeply. This has been thoroughly tested.
- QSP now accepts an optional onChangeFunction that is called whenever the query updates. It's such a common thing, to want to act on listened query changes, so this saves needing to use AutoRequest explicitly every time.

Plus can you please bump a version and publish it once pulled in?
